### PR TITLE
Better benchmarking

### DIFF
--- a/benchmark.cc
+++ b/benchmark.cc
@@ -2,6 +2,7 @@
 #include <random>
 #include <vector>
 #include <iostream>
+#include <iomanip>
 #include <fstream>
 #include <chrono>
 #include <deque>
@@ -14,42 +15,18 @@ int main()
   using namespace std::chrono;
   using namespace rpnx;
 
-  std::ofstream o1("monoque_benchmark.txt");
-  //  std::ofstream o1r("monoque::operator[]const.txt");
-  std::ofstream o2("vector_benchmark.txt");
-  // std::ofstream o2r("vector::operator[]const.txt");
-  std::ofstream o3("deque_benchmark.txt");
-
   mt19937_64 r;
- 
+
   size_t round_count = 300000000;
   size_t round_secondary = round_count*4;
+  size_t runs = 3;
 
-  /*
-  {
-    monoque<int> m;
-    for (int i = 0; i < round_count; i++)
-    {
-      m.push_back(i);
-    }
-  }
-
-  {
-    vector<int> m;
-    for (int i = 0; i < round_count; i++)
-    {
-      m.push_back(i);
-    }
-  }
-  */
-  
   vector<size_t> rds;
-
-  for (int i = 0; i < round_count; i++)
+  for (size_t i = 0; i < round_count; i++)
     {
       rds.push_back(r() % round_count);
     }
-  
+
   system_clock::time_point start_time;
   system_clock::time_point end_time;
 
@@ -57,119 +34,98 @@ int main()
   system_clock::time_point end_time_tt;
 
   cout  << "For linear structures of size " << round_count << " and random access " << round_secondary << " times, discovered that: " << endl;
- 
+
+  double fast_push = std::numeric_limits<double>::max();
+  double fast_access = std::numeric_limits<double>::max();
+  cout << fixed;
+
+
+  fast_push = std::numeric_limits<double>::max();
+  fast_access = std::numeric_limits<double>::max();
+  for (size_t r=0 ; r<runs ; ++r)
   {
-    vector<int> m;
+    vector<size_t> m;
     start_time = system_clock::now();
 
-    volatile int tester;
-  
     for (size_t i = 0; i < round_count; i++)
     {
-      tester = i;      
-      m.push_back(int(tester));    
-    }
-    end_time = system_clock::now();
-    cout << "vector<int> average push_back time: " << (double)(duration_cast<nanoseconds>(end_time-start_time).count())/round_count << " nanoseconds" << endl;
-    this_thread::yield();
-    
-    start_time = system_clock::now();
-    for (size_t i = 0; i < round_secondary; i++)
-    {     
-      tester = m[rds[i % round_count]];
-    }
-    end_time = system_clock::now();
-    cout << "vector<int> average random access time: " << (double)(duration_cast<nanoseconds>(end_time-start_time).count())/round_secondary << " nanoseconds" << endl;
-    
-  }
-
-  {
-    monoque<int> m;
-    start_time = system_clock::now();
-
-    volatile int tester;
-  
-    for (size_t i = 0; i < round_count; i++)
-    {
-      tester = i;      
-      m.push_back(int(tester));    
-    }
-    end_time = system_clock::now();
-    cout << "monoque<int> average push_back time: " << (double)(duration_cast<nanoseconds>(end_time-start_time).count())/round_count << " nanoseconds" << endl;
-    this_thread::yield();
-    
-    start_time = system_clock::now();
-    for (size_t i = 0; i < round_secondary; i++)
-    {     
-      tester = m[rds[i % round_count]];
-    }
-    end_time = system_clock::now();
-    cout << "monoque<int> average random access time: " << (double)(duration_cast<nanoseconds>(end_time-start_time).count())/round_secondary << " nanoseconds" << endl;
-    
-  }
-
-
-
- /*
-  {
-
-
-    vector<int> m;
-    for (int  i = 0; i < round_count; i++)
-    {
-      start_time = system_clock::now();
-      std::atomic_signal_fence(memory_order_seq_cst);
       m.push_back(i);
-      std::atomic_signal_fence(memory_order_seq_cst);
-      end_time = system_clock::now();
-      o2 << duration_cast<nanoseconds>(end_time-start_time).count() << endl;
-      this_thread::yield();
-    }
-
-
-    start_time = system_clock::now();
-    volatile int tester;
-    for (int i = 0; i < round_count; i++)
-    {
-      std::atomic_signal_fence(memory_order_seq_cst);
-      tester = m[rds[i]];      
-      std::atomic_signal_fence(memory_order_seq_cst);
     }
     end_time = system_clock::now();
-    //duration_cast<nanoseconds>(end_time-start_time).count())/round_count << endl;
+    fast_push = std::min(fast_push, (double)(duration_cast<nanoseconds>(end_time-start_time).count()));
+    cout << m.size() << ' ' << fast_push << endl;
+
+    start_time = system_clock::now();
+    size_t t = 0;
+    for (size_t i = 0; i < round_secondary; i++)
+    {
+      t += m[rds[i % round_count]];
+    }
+    end_time = system_clock::now();
+    fast_access = std::min(fast_access, (double)(duration_cast<nanoseconds>(end_time-start_time).count()));
+    cout << t << ' ' << fast_access << endl;
 
   }
- */
-  
+  cout << "vector<size_t> average push_back time: " << fast_push/round_count << " nanoseconds" << endl;
+  cout << "vector<size_t> average random access time: " << fast_access/round_secondary << " nanoseconds" << endl;
 
 
+  fast_push = std::numeric_limits<double>::max();
+  fast_access = std::numeric_limits<double>::max();
+  for (size_t r=0 ; r<runs ; ++r)
   {
-   
-    deque<int> m;
-    volatile int tester;
+    monoque<size_t> m;
+    start_time = system_clock::now();
+
+    for (size_t i = 0; i < round_count; i++)
+    {
+      m.push_back(i);
+    }
+    end_time = system_clock::now();
+    fast_push = std::min(fast_push, (double)(duration_cast<nanoseconds>(end_time-start_time).count()));
+    cout << m.size() << ' ' << fast_push << endl;
+
+    start_time = system_clock::now();
+    size_t t = 0;
+    for (size_t i = 0; i < round_secondary; i++)
+    {
+      t += m[rds[i % round_count]];
+    }
+    end_time = system_clock::now();
+    fast_access = std::min(fast_access, (double)(duration_cast<nanoseconds>(end_time-start_time).count()));
+    cout << t << ' ' << fast_access << endl;
+
+  }
+  cout << "monoque<size_t> average push_back time: " << fast_push/round_count << " nanoseconds" << endl;
+  cout << "monoque<size_t> average random access time: " << fast_access/round_secondary << " nanoseconds" << endl;
+
+
+  fast_push = std::numeric_limits<double>::max();
+  fast_access = std::numeric_limits<double>::max();
+  for (size_t r=0 ; r<runs ; ++r)
+  {
+    deque<size_t> m;
 
     start_time = system_clock::now();
     for (size_t  i = 0; i < round_count; i++)
     {
-      tester = i;
-      m.push_back(int(tester));
+      m.push_back(i);
     }
     end_time = system_clock::now();
-    cout << "deque<int> average push_back time: " << double(duration_cast<nanoseconds>(end_time-start_time).count())/round_count <<  " nanoseconds" << endl;
-    this_thread::yield();
+    fast_push = std::min(fast_push, (double)(duration_cast<nanoseconds>(end_time-start_time).count()));
+    cout << m.size() << ' ' << fast_push << endl;
 
     start_time = system_clock::now();
-    
+    size_t t = 0;
     for (size_t i = 0; i < round_secondary; i++)
     {
-      tester = m[rds[i % round_count]];
+      t += m[rds[i % round_count]];
     }
-
     end_time = system_clock::now();
-    cout << "deque<int> average random access time: " << (double)(duration_cast<nanoseconds>(end_time-start_time).count())/round_secondary << " nanoseconds" << endl;
+    fast_access = std::min(fast_access, (double)(duration_cast<nanoseconds>(end_time-start_time).count()));
+    cout << t << ' ' << fast_access << endl;
 
   }
-
-  return 0;
-
+  cout << "deque<size_t> average push_back time: " << fast_push/round_count <<  " nanoseconds" << endl;
+  cout << "deque<size_t> average random access time: " << fast_access/round_secondary << " nanoseconds" << endl;
 }


### PR DESCRIPTION
Your code, adjusted to use size_t, yields:
```
vector<size_t> average push_back time: 18.7362 nanoseconds
vector<size_t> average random access time: 25.307 nanoseconds
monoque<size_t> average push_back time: 9.15348 nanoseconds
monoque<size_t> average random access time: 20.2767 nanoseconds
deque<size_t> average push_back time: 3.89454 nanoseconds
deque<size_t> average random access time: 37.1108 nanoseconds
```

My quick edit yields:
```
vector<size_t> average push_back time: 19.401001 nanoseconds
vector<size_t> average random access time: 23.522036 nanoseconds
monoque<size_t> average push_back time: 8.997497 nanoseconds
monoque<size_t> average random access time: 30.155601 nanoseconds
deque<size_t> average push_back time: 3.986472 nanoseconds
deque<size_t> average random access time: 45.720249 nanoseconds
```

Which is the result I would expect - Monoque is a middle-ground between vector and deque.

It runs each container 3 times and takes the fastest time. This makes a huge difference - the 3rd time the access loop is run is much faster than the first, thanks to various priming, and thus a more realistic result. And it uses the data in a way that cannot be easily optimized out - by outputting the sum.